### PR TITLE
fix: prevent duplicate user message in StreamController requests

### DIFF
--- a/src/Http/Controllers/StreamController.php
+++ b/src/Http/Controllers/StreamController.php
@@ -98,6 +98,18 @@ class StreamController
 
                 $messages = $conversationManager->getMessagesForAgent($conversation);
 
+                // `addUserMessage()` above has already persisted the current user
+                // message, so `getMessagesForAgent()` returns it as the trailing
+                // row. Extract that content for `prompt:` and drop the row from
+                // the history we pass to `withMessages()`. Otherwise laravel/ai's
+                // `Promptable::stream()` wraps `prompt:` as a NEW user message on
+                // top of the already-present row, duplicating the user's latest
+                // message in every outgoing request body.
+                $lastUserMessage = '';
+                if (! empty($messages) && end($messages)['role'] === 'user') {
+                    $lastUserMessage = array_pop($messages)['content'];
+                }
+
                 $agent->forPanel($panelId)
                     ->forUser($user)
                     ->forTenant($tenant)
@@ -107,13 +119,6 @@ class StreamController
 
                 $provider = $plugin->getProvider();
                 $model = $plugin->getModel();
-
-                $lastUserMessage = '';
-                foreach ($messages as $msg) {
-                    if ($msg['role'] === 'user') {
-                        $lastUserMessage = $msg['content'];
-                    }
-                }
 
                 // Send start event
                 $this->sendSseEvent('start', []);


### PR DESCRIPTION
StreamController::stream() reads the full history via getMessagesForAgent() (which includes the user's just-addUserMessage'd current turn), passes it via ->withMessages($messages), then re-extracts the last user message from the same array and passes it as ->stream(prompt: $lastUserMessage). laravel/ai's Promptable::stream() wraps `prompt:` as a new UserMessage on top of the existing history via AgentPrompt + the provider's StreamsText concern, so the user's current message ends up in the outgoing request body twice.

Visible as two consecutive identical `{"role": "user", ...}` entries in raw proxy logs (e.g. LiteLLM / OpenAI). Benign but inflates prompt tokens by roughly 15-100 per turn on every copilot request.

Fix: extract and `array_pop` the trailing user row from `$messages` before calling `->withMessages()`, then pass its content as `prompt:` to `->stream()`. Guarded to only pop when the trailing row is a user role, so histories ending in an assistant message (e.g. a mid-conversation regeneration flow) still work unchanged.

Closes #10 