### PR TITLE
Widen laravel/ai constraint to ^0.4.0 || ^0.5.0 || ^0.6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "require": {
     "php": "^8.2",
     "filament/filament": "^5.0",
-    "laravel/ai": "^0.4.0",
+    "laravel/ai": "^0.4.0 || ^0.5.0 || ^0.6.0",
     "laravel/prompts": "^0.3.14",
     "spatie/laravel-package-tools": "^1.16"
   },


### PR DESCRIPTION
No breaking changes. The 0.6 changes touched gateway internals (DeepSeek/Groq/Gemini structured-output handling, native OpenRouter/Ollama/DeepSeek/AzureOpenAi/VoyageAi gateways, Bedrock provider) and the `Agent` contract gained an optional `timeout` parameter, none of which affect plugin's call sites. 