### PR TITLE
feat(tool-registry): accept tool instances and closure factories

### DIFF
--- a/src/Services/ToolRegistry.php
+++ b/src/Services/ToolRegistry.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EslamRedaDiv\FilamentCopilot\Services;
 
+use Closure;
 use EslamRedaDiv\FilamentCopilot\Tools\BaseTool;
 use EslamRedaDiv\FilamentCopilot\Tools\GetToolsTool;
 use EslamRedaDiv\FilamentCopilot\Tools\ListPagesTool;
@@ -33,10 +34,17 @@ class ToolRegistry
 
     /**
      * Register a global custom tool.
+     *
+     * Accepts a class-string (resolved via the container), a tool instance,
+     * or a closure. Closures are invoked on every buildTools() call and may
+     * return a single tool or an iterable of tools — this is how runtime-only
+     * tools (e.g. laravel/ai ^0.8 MCP client tools, which are instances
+     * produced by an MCP connection rather than resolvable classes) can be
+     * registered. Memoize inside the closure if resolution is expensive.
      */
-    public function registerGlobal(string $toolClass): void
+    public function registerGlobal(string|object $tool): void
     {
-        $this->globalTools[] = $toolClass;
+        $this->globalTools[] = $tool;
     }
 
     /**
@@ -55,27 +63,57 @@ class ToolRegistry
 
         $tools = [];
 
-        foreach (array_merge($this->toolClasses, $this->globalTools, $pluginTools) as $toolClass) {
-            $tool = app($toolClass);
+        foreach (array_merge($this->toolClasses, $this->globalTools, $pluginTools) as $entry) {
+            foreach ($this->resolveTools($entry) as $tool) {
+                if ($tool instanceof BaseTool) {
+                    $tool->forPanel($panelId)
+                        ->forUser($user)
+                        ->forTenant($tenant);
 
-            if ($tool instanceof BaseTool) {
-                $tool->forPanel($panelId)
-                    ->forUser($user)
-                    ->forTenant($tenant);
+                    if ($conversationId) {
+                        $tool->forConversation($conversationId);
+                    }
+                }
+
+                $tools[] = $tool;
             }
-
-            if ($conversationId && $tool instanceof BaseTool) {
-                $tool->forConversation($conversationId);
-            }
-
-            $tools[] = $tool;
         }
 
         return $tools;
     }
 
     /**
-     * Get the list of registered tool classes.
+     * Resolve a registered entry into zero or more tool objects.
+     */
+    protected function resolveTools(string|object $entry): iterable
+    {
+        if (is_string($entry)) {
+            $entry = app($entry);
+        }
+
+        if ($entry instanceof Closure) {
+            $entry = $entry();
+        }
+
+        if ($entry === null) {
+            return;
+        }
+
+        if (is_iterable($entry)) {
+            foreach ($entry as $tool) {
+                if ($tool !== null) {
+                    yield $tool;
+                }
+            }
+
+            return;
+        }
+
+        yield $entry;
+    }
+
+    /**
+     * Get the list of registered tool entries (class-strings, instances, or closures).
      */
     public function getToolClasses(): array
     {

--- a/tests/Unit/Services/ToolRegistryTest.php
+++ b/tests/Unit/Services/ToolRegistryTest.php
@@ -16,3 +16,83 @@ it('accepts global custom tools', function () {
     $registry->registerGlobal('App\\Tools\\CustomTool');
     expect(count($registry->getToolClasses()))->toBe(8);
 });
+
+it('accepts tool instances', function () {
+    $user = createTestUser();
+    $registry = app(ToolRegistry::class);
+
+    $instance = new class
+    {
+        public string $name = 'runtime_tool';
+    };
+
+    $registry->registerGlobal($instance);
+    $tools = $registry->buildTools('admin', $user);
+
+    expect(count($tools))->toBe(8)
+        ->and($tools)->toContain($instance);
+});
+
+it('accepts closures returning a single tool', function () {
+    $user = createTestUser();
+    $registry = app(ToolRegistry::class);
+
+    $instance = new class
+    {
+        public string $name = 'lazy_tool';
+    };
+
+    $registry->registerGlobal(fn () => $instance);
+    $tools = $registry->buildTools('admin', $user);
+
+    expect(count($tools))->toBe(8)
+        ->and($tools)->toContain($instance);
+});
+
+it('accepts closures returning an iterable of tools', function () {
+    $user = createTestUser();
+    $registry = app(ToolRegistry::class);
+
+    $first = new class
+    {
+        public string $name = 'mcp_tool_one';
+    };
+    $second = new class
+    {
+        public string $name = 'mcp_tool_two';
+    };
+
+    $registry->registerGlobal(fn () => [$first, $second]);
+    $tools = $registry->buildTools('admin', $user);
+
+    expect(count($tools))->toBe(9)
+        ->and($tools)->toContain($first)
+        ->and($tools)->toContain($second);
+});
+
+it('skips closures resolving to null', function () {
+    $user = createTestUser();
+    $registry = app(ToolRegistry::class);
+
+    $registry->registerGlobal(fn () => null);
+    $tools = $registry->buildTools('admin', $user);
+
+    expect(count($tools))->toBe(7);
+});
+
+it('re-invokes closures on every build', function () {
+    $user = createTestUser();
+    $registry = app(ToolRegistry::class);
+
+    $calls = 0;
+    $registry->registerGlobal(function () use (&$calls) {
+        $calls++;
+
+        return null;
+    });
+
+    $registry->buildTools('admin', $user);
+    $registry->buildTools('admin', $user);
+
+    expect($calls)->toBe(2);
+});


### PR DESCRIPTION
This commit follows the new MCP functionality added with laravel/ai. registerGlobal() previously accepted only class-strings resolved via the container, which makes it impossible to register tools that only exist as runtime instances -laravel/ai ^0.8 MCP client tools (Laravel\Mcp\Client\Primitives\Tool objects produced by an MCP connection, auto-wrapped by laravel/ai's resolveTool()).

registerGlobal() now also accepts a tool instance or a closure. A closure is invoked on every buildTools() call and may return a single tool, an iterable of tools (one MCP server exposing several tools), or null (server unavailable - skipped gracefully). BaseTool context binding (panel/user/tenant/conversation) is unchanged and applies to resolved instances as before. Class-string registration is untouched, including plugin- and config-provided entries.