### PR TITLE
Widen laravel/ai constraint to allow ^0.9.0 and ^0.10.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "require": {
     "php": "^8.2",
     "filament/filament": "^5.0",
-    "laravel/ai": "^0.4.0 || ^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0",
+    "laravel/ai": "^0.4.0 || ^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0",
     "laravel/prompts": "^0.3.14",
     "spatie/laravel-package-tools": "^1.16"
   },


### PR DESCRIPTION
Full test suite passes against laravel/ai v0.10.1. 
Just FYI - new human-in-the-loop (manual tool approval) is not supported, but haven't tested 100%