### PR TITLE
feat(feedback): thumbs up/down rating on assistant messages (refs #18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Filament Copilot integrates directly into your Filament panels with a chat inter
   - [Audit Logging](#audit-logging)
   - [Agent Memory](#agent-memory)
   - [Management Dashboard](#management-dashboard)
+  - [Message Feedback](#message-feedback)
   - [Quick Actions](#quick-actions)
   - [System Prompt](#system-prompt)
   - [Global Tools](#global-tools)
@@ -112,6 +113,7 @@ Filament Copilot integrates directly into your Filament panels with a chat inter
 - **9 Tool Templates** — Generate tools instantly with the `make:copilot-tool` artisan command (list, view, search, create, edit, delete, force-delete, restore, custom).
 - **Conversation History** — Full conversation persistence with a sidebar for browsing, loading, and deleting past conversations.
 - **Agent Memory** — The AI remembers facts across conversations using a per-user key-value memory store (Remember & Recall tools).
+- **Message Feedback** — Thumbs up/down on assistant replies, surfaced back to admins as a thumbs-down count and a "has negative rating" filter on the conversations table.
 - **Audit Logging** — Comprehensive audit trail tracking messages, tool calls, record access, and navigation events.
 - **Rate Limiting** — Per-user hourly/daily message and token rate limits with automatic blocking and unblocking.
 - **Token Budget Tracking** — Daily and monthly token budget tracking with configurable warning thresholds.
@@ -122,7 +124,7 @@ Filament Copilot integrates directly into your Filament panels with a chat inter
 - **Authorization Aware** — Respects Filament's authorization policies out of the box.
 - **Fully Translatable** — All UI strings are translatable with a complete English language file (100+ keys).
 - **Publishable Assets, Config, Views, Stubs** — Customize everything to fit your needs.
-- **81 Tests** — Comprehensive test suite covering models, services, tools, Livewire components, discovery, enums, config, plugin, and streaming.
+- **121 Tests** — Comprehensive test suite covering models, services, tools, Livewire components, views, discovery, enums, config, plugin, and streaming.
 
 ---
 
@@ -284,6 +286,25 @@ The AI agent can remember facts across conversations. Memories are scoped per-us
 ```
 
 Enable the built-in management UI to view conversations, audit logs, rate limits, token usage charts, and top users — all within your Filament panel.
+
+### Message Feedback
+
+```php
+'feedback' => [
+    'enabled' => true,
+],
+```
+
+Adds a thumbs up / thumbs down control under every assistant reply in the chat. One click rates the reply, clicking the lit thumb again clears it, and the rating is stored on `copilot_messages.rating` (`positive`, `negative`, or `null`).
+
+Ratings are only accepted for assistant messages in the signed-in participant's own conversations, scoped by panel and tenant like every other conversation lookup in the package.
+
+Admins get the feedback back in the management dashboard's **Conversations** resource:
+
+- a **Thumbs Down** badge column, shown only for the conversations that actually collected one, and
+- a **Has Negative Rating** filter for jumping straight to the conversations that went wrong.
+
+Set `enabled` to `false` to hide the buttons and stop accepting ratings. Ratings already recorded are kept and still reported in the management UI.
 
 ### Quick Actions
 
@@ -764,7 +785,7 @@ The package creates 7 database tables:
 | Table                    | Model                 | Description                                                  |
 | ------------------------ | --------------------- | ------------------------------------------------------------ |
 | `copilot_conversations`  | `CopilotConversation` | Conversation storage with polymorphic participant and tenant |
-| `copilot_messages`       | `CopilotMessage`      | Message history with role enum and token tracking            |
+| `copilot_messages`       | `CopilotMessage`      | Message history with role enum, token tracking, and feedback rating |
 | `copilot_tool_calls`     | `CopilotToolCall`     | Tool call tracking with approval status workflow             |
 | `copilot_audit_logs`     | `CopilotAuditLog`     | Detailed audit trail with 25 action types                    |
 | `copilot_rate_limits`    | `CopilotRateLimit`    | Per-user rate limit configuration and blocking               |
@@ -778,6 +799,7 @@ All models use ULIDs as primary keys and support polymorphic relationships for p
 | Enum             | Values                                                                                   |
 | ---------------- | ---------------------------------------------------------------------------------------- |
 | `MessageRole`    | `User`, `Assistant`, `System`, `Tool`                                                    |
+| `MessageRating`  | `Positive`, `Negative`                                                                   |
 | `ToolCallStatus` | `Pending`, `Approved`, `Rejected`, `Executed`, `Failed`                                  |
 | `AuditAction`    | 25 actions including `MessageSent`, `ToolCalled`, `RecordCreated`, `RecordDeleted`, etc. |
 
@@ -799,7 +821,7 @@ This adds:
   - **Stats Overview** — 4 cards showing total conversations, messages, tool calls, and active users
   - **Token Usage Chart** — 30-day line chart of daily token consumption
   - **Top Users Table** — Sortable table of the most active copilot users
-- **Conversations Resource** — Browse, view, and manage all copilot conversations
+- **Conversations Resource** — Browse, view, and manage all copilot conversations, including the thumbs-down count and the "has negative rating" filter from [Message Feedback](#message-feedback)
 - **Audit Logs Resource** — Search and filter the complete audit trail
 - **Rate Limits Resource** — Manage per-user rate limits and blocking
 
@@ -866,12 +888,13 @@ Stubs are published to `stubs/filament-copilot/` in your project root.
 
 ## Testing
 
-The package includes 81 tests with 159 assertions covering:
+The package includes 121 tests with 254 assertions covering:
 
 - Models & relationships
 - Services (ConversationManager, ToolRegistry, RateLimitService, ExportService)
 - Built-in tools
 - Livewire components
+- Blade views
 - Discovery inspectors
 - Enums
 - Configuration

--- a/config/filament-copilot.php
+++ b/config/filament-copilot.php
@@ -111,6 +111,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Message Feedback
+    |--------------------------------------------------------------------------
+    | Thumbs up / down on assistant replies. When disabled the buttons are
+    | hidden and ratings can no longer be submitted; ratings already stored on
+    | copilot_messages.rating are kept and still reported in the management UI.
+    */
+
+    'feedback' => [
+        'enabled' => true,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Quick Actions / Canned Prompts
     |--------------------------------------------------------------------------
     */

--- a/database/migrations/2024_01_01_000009_add_rating_to_copilot_messages_table.php
+++ b/database/migrations/2024_01_01_000009_add_rating_to_copilot_messages_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('copilot_messages', function (Blueprint $table) {
+            // 'positive' | 'negative' | null (never rated, or rating cleared).
+            $table->string('rating')->nullable()->after('content');
+
+            // Conversation first: the management table filters conversations by
+            // "has a negative-rated message", which is an equality lookup on
+            // (conversation_id, rating). A plain rating index would still force
+            // a per-conversation row scan.
+            $table->index(['conversation_id', 'rating']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('copilot_messages', function (Blueprint $table) {
+            $table->dropIndex(['conversation_id', 'rating']);
+            $table->dropColumn('rating');
+        });
+    }
+};

--- a/resources/lang/en/filament-copilot.php
+++ b/resources/lang/en/filament-copilot.php
@@ -33,6 +33,18 @@ return [
     'rate_limit_exceeded' => 'You have exceeded the rate limit. Please try again later.',
     'error_occurred' => 'An error occurred',
 
+    // Message Feedback
+    'feedback_helpful' => 'Helpful',
+    'feedback_not_helpful' => 'Not helpful',
+    'feedback_remove_helpful' => 'Remove helpful rating',
+    'feedback_remove_not_helpful' => 'Remove unhelpful rating',
+    'thumbs_up' => 'Thumbs Up',
+    'thumbs_down' => 'Thumbs Down',
+    'has_negative_rating' => 'Has Negative Rating',
+    'all_conversations' => 'All conversations',
+    'with_negative_rating' => 'With thumbs down',
+    'without_negative_rating' => 'Without thumbs down',
+
     // Ask User
     'question_from_copilot' => 'Copilot needs your input:',
     'approve' => 'Approve',

--- a/resources/views/components/chat-message.blade.php
+++ b/resources/views/components/chat-message.blade.php
@@ -71,6 +71,13 @@
         </div>
     </div>
 @elseif($isAssistant)
+    {{-- Feedback thumbs. Only a persisted message carries an id, so the id gate
+         doubles as the "is there something rateable to talk to" gate. --}}
+    @php
+        $messageId = $msg['id'] ?? null;
+        $rating = $msg['rating'] ?? null;
+        $showFeedback = $messageId !== null && config('filament-copilot.feedback.enabled', true);
+    @endphp
     <div class="flex items-start gap-2.5">
         <div
             class="w-7 h-7 rounded-full bg-primary-100 dark:bg-primary-900/30 flex items-center justify-center shrink-0 mt-0.5">
@@ -83,6 +90,34 @@
                 {!! \Illuminate\Support\Str::markdown($msg['content'] ?? '') !!}
             </div>
         </div>
+        @if ($showFeedback)
+            @php
+                $helpfulLabel = $rating === 'positive'
+                    ? __('filament-copilot::filament-copilot.feedback_remove_helpful')
+                    : __('filament-copilot::filament-copilot.feedback_helpful');
+                $notHelpfulLabel = $rating === 'negative'
+                    ? __('filament-copilot::filament-copilot.feedback_remove_not_helpful')
+                    : __('filament-copilot::filament-copilot.feedback_not_helpful');
+            @endphp
+            <div class="flex items-center gap-0.5 shrink-0 self-end">
+                <button type="button" wire:click="submitRating('{{ $messageId }}', 'positive')"
+                    wire:loading.attr="disabled" wire:target="submitRating"
+                    class="flex items-center justify-center w-6 h-6 rounded-md transition duration-75 hover:bg-gray-500/5 dark:hover:bg-gray-400/5 {{ $rating === 'positive' ? 'text-success-600 dark:text-success-400' : 'text-gray-400 dark:text-gray-500 opacity-50 hover:opacity-100' }}"
+                    title="{{ $helpfulLabel }}" aria-label="{{ $helpfulLabel }}"
+                    aria-pressed="{{ $rating === 'positive' ? 'true' : 'false' }}">
+                    <x-filament::icon :icon="$rating === 'positive' ? 'heroicon-s-hand-thumb-up' : 'heroicon-o-hand-thumb-up'"
+                        class="w-3.5 h-3.5" />
+                </button>
+                <button type="button" wire:click="submitRating('{{ $messageId }}', 'negative')"
+                    wire:loading.attr="disabled" wire:target="submitRating"
+                    class="flex items-center justify-center w-6 h-6 rounded-md transition duration-75 hover:bg-gray-500/5 dark:hover:bg-gray-400/5 {{ $rating === 'negative' ? 'text-danger-600 dark:text-danger-400' : 'text-gray-400 dark:text-gray-500 opacity-50 hover:opacity-100' }}"
+                    title="{{ $notHelpfulLabel }}" aria-label="{{ $notHelpfulLabel }}"
+                    aria-pressed="{{ $rating === 'negative' ? 'true' : 'false' }}">
+                    <x-filament::icon :icon="$rating === 'negative' ? 'heroicon-s-hand-thumb-down' : 'heroicon-o-hand-thumb-down'"
+                        class="w-3.5 h-3.5" />
+                </button>
+            </div>
+        @endif
     </div>
 @elseif($isSystem)
     <div class="flex justify-center px-4">

--- a/resources/views/livewire/copilot-chat.blade.php
+++ b/resources/views/livewire/copilot-chat.blade.php
@@ -138,6 +138,7 @@
             const decoder = new TextDecoder();
             let buffer = '';
             let newConversationId = null;
+            let assistantMessageId = null;
 
             while (true) {
                 const { done, value } = await reader.read();
@@ -198,6 +199,9 @@
                                     this.toolCalls = [];
                                     break;
                                 case 'done':
+                                    // Absent on error streams, and on servers
+                                    // running an older package release.
+                                    assistantMessageId = data.message_id || null;
                                     break;
                             }
                         } catch (e) {
@@ -220,6 +224,7 @@
                     content: this.streamedContent,
                     newConversationId: newConversationId,
                     toolCalls: this.toolCalls.length ? JSON.parse(JSON.stringify(this.toolCalls)) : null,
+                    messageId: assistantMessageId,
                 });
 
                 // Execute pending navigation after stream completes

--- a/src/Enums/MessageRating.php
+++ b/src/Enums/MessageRating.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EslamRedaDiv\FilamentCopilot\Enums;
+
+enum MessageRating: string
+{
+    case Positive = 'positive';
+    case Negative = 'negative';
+}

--- a/src/Http/Controllers/StreamController.php
+++ b/src/Http/Controllers/StreamController.php
@@ -240,7 +240,11 @@ class StreamController
                     'output_tokens' => $usage->completionTokens ?? 0,
                 ]);
 
-                $this->sendSseEvent('done', []);
+                // The persisted assistant message id lets the chat component
+                // reference the reply it just streamed — for message feedback,
+                // and for anything else that needs to address it later. Older
+                // published copies of the chat view simply ignore the payload.
+                $this->sendSseEvent('done', ['message_id' => $assistantMessage->id]);
             } catch (\Throwable $e) {
                 $this->sendSseEvent('error', ['message' => $e->getMessage()]);
                 $this->sendSseEvent('done', []);

--- a/src/Livewire/CopilotChat.php
+++ b/src/Livewire/CopilotChat.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace EslamRedaDiv\FilamentCopilot\Livewire;
 
+use EslamRedaDiv\FilamentCopilot\Enums\MessageRating;
+use EslamRedaDiv\FilamentCopilot\Enums\MessageRole;
 use EslamRedaDiv\FilamentCopilot\FilamentCopilotPlugin;
 use EslamRedaDiv\FilamentCopilot\Models\CopilotConversation;
+use EslamRedaDiv\FilamentCopilot\Models\CopilotMessage;
 use EslamRedaDiv\FilamentCopilot\Services\ConversationManager;
 use EslamRedaDiv\FilamentCopilot\Services\ExportService;
 use Filament\Facades\Filament;
@@ -88,9 +91,15 @@ class CopilotChat extends Component
 
     /**
      * Called from JavaScript after SSE streaming completes.
+     *
+     * `$messageId` is the id `StreamController` persisted for this reply and
+     * echoed back in the SSE `done` payload. It is optional so a published copy
+     * of the chat view that predates that payload keeps working — the reply is
+     * then simply rendered without feedback buttons until the conversation is
+     * reloaded.
      */
     #[On('copilot-stream-complete')]
-    public function handleStreamComplete(string $content, ?string $newConversationId = null, ?array $toolCalls = null): void
+    public function handleStreamComplete(string $content, ?string $newConversationId = null, ?array $toolCalls = null, ?string $messageId = null): void
     {
         if ($newConversationId && ! $this->conversationId) {
             $this->conversationId = $newConversationId;
@@ -111,12 +120,91 @@ class CopilotChat extends Component
             }
         }
 
-        $this->messages[] = [
+        $assistantMessage = [
             'role' => 'assistant',
             'content' => $content,
         ];
 
+        // Not trusted as proof of ownership — it only decides whether the
+        // buttons render. Every write still goes through submitRating(), which
+        // re-resolves the message against the current participant.
+        if ($messageId !== null) {
+            $assistantMessage['id'] = $messageId;
+            $assistantMessage['rating'] = null;
+        }
+
+        $this->messages[] = $assistantMessage;
+
         $this->loadConversations();
+    }
+
+    /**
+     * Record (or clear) a thumbs up/down on one assistant message.
+     *
+     * Ownership is resolved in the database before anything the caller sent is
+     * validated: a message belonging to somebody else's conversation must not
+     * even reveal that it exists, so every rejection is the same silent no-op.
+     */
+    public function submitRating(string $messageId, string $rating): void
+    {
+        if (! config('filament-copilot.feedback.enabled', true)) {
+            return;
+        }
+
+        $user = Filament::auth()->user();
+        $panelId = Filament::getCurrentPanel()?->getId();
+
+        if (! $user || ! $panelId) {
+            return;
+        }
+
+        $tenant = Filament::getTenant();
+
+        $message = CopilotMessage::query()
+            ->whereKey($messageId)
+            ->whereHas('conversation', fn ($query) => $query
+                ->forPanel($panelId)
+                ->forParticipant($user)
+                ->forTenant($tenant))
+            ->first();
+
+        if (! $message) {
+            return;
+        }
+
+        $rating = MessageRating::tryFrom($rating);
+
+        if (! $rating) {
+            return;
+        }
+
+        // Only the copilot's own replies are ratable — never the user's own
+        // text, system notices or tool output.
+        if ($message->role !== MessageRole::Assistant) {
+            return;
+        }
+
+        // Clicking the thumb that is already lit clears the rating.
+        $message->update([
+            'rating' => $message->rating === $rating ? null : $rating,
+        ]);
+
+        $this->applyRatingToMessages($messageId, $message->rating?->value);
+    }
+
+    /**
+     * Reflect a new rating in the component state so the thumb lights up
+     * without reloading the conversation.
+     */
+    protected function applyRatingToMessages(string $messageId, ?string $rating): void
+    {
+        foreach ($this->messages as $index => $message) {
+            if (($message['id'] ?? null) === $messageId) {
+                $this->messages[$index]['rating'] = $rating;
+
+                return;
+            }
+        }
     }
 
     /**

--- a/src/Models/CopilotMessage.php
+++ b/src/Models/CopilotMessage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EslamRedaDiv\FilamentCopilot\Models;
 
+use EslamRedaDiv\FilamentCopilot\Enums\MessageRating;
 use EslamRedaDiv\FilamentCopilot\Enums\MessageRole;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Model;
@@ -18,6 +19,7 @@ class CopilotMessage extends Model
         'conversation_id',
         'role',
         'content',
+        'rating',
         'metadata',
         'input_tokens',
         'output_tokens',
@@ -27,6 +29,7 @@ class CopilotMessage extends Model
     {
         return [
             'role' => MessageRole::class,
+            'rating' => MessageRating::class,
             'metadata' => 'array',
             'input_tokens' => 'integer',
             'output_tokens' => 'integer',

--- a/src/Resources/CopilotConversations/Tables/CopilotConversationsTable.php
+++ b/src/Resources/CopilotConversations/Tables/CopilotConversationsTable.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EslamRedaDiv\FilamentCopilot\Resources\CopilotConversations\Tables;
 
+use EslamRedaDiv\FilamentCopilot\Enums\MessageRating;
 use EslamRedaDiv\FilamentCopilot\Models\CopilotConversation;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
@@ -11,7 +12,9 @@ use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 
 class CopilotConversationsTable
 {
@@ -36,6 +39,19 @@ class CopilotConversationsTable
                     ->label(__('filament-copilot::filament-copilot.messages'))
                     ->counts('messages')
                     ->sortable(),
+                TextColumn::make('negative_rating_count')
+                    ->label(__('filament-copilot::filament-copilot.thumbs_down'))
+                    ->counts([
+                        'messages as negative_rating_count' => fn (Builder $query): Builder => $query
+                            ->where('rating', MessageRating::Negative->value),
+                    ])
+                    ->badge()
+                    ->color('danger')
+                    // A zero badge on nearly every row is noise — only flag the
+                    // conversations somebody actually complained about.
+                    ->formatStateUsing(fn ($state): ?string => ((int) $state) > 0 ? (string) $state : null)
+                    ->placeholder('')
+                    ->sortable(),
                 TextColumn::make('created_at')
                     ->label(__('filament-copilot::filament-copilot.created_at'))
                     ->dateTime()
@@ -54,6 +70,20 @@ class CopilotConversationsTable
                         ->distinct()
                         ->pluck('panel_id', 'panel_id')
                         ->toArray()),
+                TernaryFilter::make('has_negative_rating')
+                    ->label(__('filament-copilot::filament-copilot.has_negative_rating'))
+                    ->placeholder(__('filament-copilot::filament-copilot.all_conversations'))
+                    ->trueLabel(__('filament-copilot::filament-copilot.with_negative_rating'))
+                    ->falseLabel(__('filament-copilot::filament-copilot.without_negative_rating'))
+                    ->queries(
+                        true: fn (Builder $query): Builder => $query
+                            ->whereHas('messages', fn (Builder $messages): Builder => $messages
+                                ->where('rating', MessageRating::Negative->value)),
+                        false: fn (Builder $query): Builder => $query
+                            ->whereDoesntHave('messages', fn (Builder $messages): Builder => $messages
+                                ->where('rating', MessageRating::Negative->value)),
+                        blank: fn (Builder $query): Builder => $query,
+                    ),
             ])
             ->recordActions([
                 ViewAction::make(),

--- a/src/Services/ConversationManager.php
+++ b/src/Services/ConversationManager.php
@@ -126,6 +126,10 @@ class ConversationManager
                 $messages = [[
                     'role' => $message->role->value,
                     'content' => $message->content,
+                    // The chat blade needs the persisted id to submit feedback
+                    // against, and the rating to render the active thumb.
+                    'id' => $message->id,
+                    'rating' => $message->rating?->value,
                 ]];
 
                 foreach ($message->toolCalls->sortBy('created_at') as $toolCall) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,8 +2,12 @@
 
 namespace EslamRedaDiv\FilamentCopilot\Tests;
 
+use BladeUI\Heroicons\BladeHeroiconsServiceProvider;
+use BladeUI\Icons\BladeIconsServiceProvider;
 use EslamRedaDiv\FilamentCopilot\FilamentCopilotServiceProvider;
+use Filament\Support\SupportServiceProvider;
 use Illuminate\Database\Eloquent\Model;
+use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
@@ -21,6 +25,12 @@ abstract class TestCase extends BaseTestCase
     protected function getPackageProviders($app): array
     {
         return [
+            // Enough of Filament for the package's own Blade views
+            // (`x-filament::icon`) to render inside tests.
+            BladeIconsServiceProvider::class,
+            BladeHeroiconsServiceProvider::class,
+            LivewireServiceProvider::class,
+            SupportServiceProvider::class,
             FilamentCopilotServiceProvider::class,
         ];
     }

--- a/tests/Unit/Livewire/CopilotChatFeedbackTest.php
+++ b/tests/Unit/Livewire/CopilotChatFeedbackTest.php
@@ -1,0 +1,259 @@
+<?php
+
+use EslamRedaDiv\FilamentCopilot\Enums\MessageRating;
+use EslamRedaDiv\FilamentCopilot\Enums\MessageRole;
+use EslamRedaDiv\FilamentCopilot\FilamentCopilotPlugin;
+use EslamRedaDiv\FilamentCopilot\Livewire\CopilotChat;
+use EslamRedaDiv\FilamentCopilot\Models\CopilotConversation;
+use EslamRedaDiv\FilamentCopilot\Models\CopilotMessage;
+use EslamRedaDiv\FilamentCopilot\Services\ConversationManager;
+use Filament\Facades\Filament;
+
+function swapFilamentForFeedbackTest($user, string $panelId = 'admin', $tenant = null): void
+{
+    $plugin = new FilamentCopilotPlugin;
+
+    $panel = new class($panelId)
+    {
+        public function __construct(private string $id) {}
+
+        public function getId(): string
+        {
+            return $this->id;
+        }
+    };
+
+    $guard = new class($user)
+    {
+        public function __construct(private $user) {}
+
+        public function user()
+        {
+            return $this->user;
+        }
+    };
+
+    $filamentManager = new class($guard, $panel, $tenant, $plugin)
+    {
+        public function __construct(private $guard, private $panel, private $tenant, private FilamentCopilotPlugin $plugin) {}
+
+        public function getPlugin(string $pluginId): FilamentCopilotPlugin
+        {
+            return $this->plugin;
+        }
+
+        public function setCurrentPanel(string $panelId): void {}
+
+        public function auth()
+        {
+            return $this->guard;
+        }
+
+        public function getCurrentPanel()
+        {
+            return $this->panel;
+        }
+
+        public function getTenant()
+        {
+            return $this->tenant;
+        }
+    };
+
+    app()->instance('filament', $filamentManager);
+    Filament::swap($filamentManager);
+}
+
+function assistantMessageFor($user, string $panelId = 'admin'): CopilotMessage
+{
+    /** @var ConversationManager $manager */
+    $manager = app(ConversationManager::class);
+
+    $conversation = $manager->create($user, $panelId);
+    $manager->addUserMessage($conversation, 'What is the total revenue?');
+
+    return $manager->addAssistantMessage($conversation, 'Revenue is $1,200 this month.');
+}
+
+it('records a rating on an assistant message', function () {
+    $user = createTestUser();
+    $message = assistantMessageFor($user);
+
+    swapFilamentForFeedbackTest($user);
+
+    $chat = new CopilotChat;
+    $chat->submitRating($message->id, 'negative');
+
+    expect($message->fresh()->rating)->toBe(MessageRating::Negative);
+});
+
+it('clears the rating when the same thumb is submitted twice', function () {
+    $user = createTestUser();
+    $message = assistantMessageFor($user);
+
+    swapFilamentForFeedbackTest($user);
+
+    $chat = new CopilotChat;
+    $chat->submitRating($message->id, 'positive');
+    $chat->submitRating($message->id, 'positive');
+
+    expect($message->fresh()->rating)->toBeNull();
+});
+
+it('replaces the rating when the opposite thumb is submitted', function () {
+    $user = createTestUser();
+    $message = assistantMessageFor($user);
+
+    swapFilamentForFeedbackTest($user);
+
+    $chat = new CopilotChat;
+    $chat->submitRating($message->id, 'negative');
+    $chat->submitRating($message->id, 'positive');
+
+    expect($message->fresh()->rating)->toBe(MessageRating::Positive);
+});
+
+it('reflects the rating in the loaded chat messages', function () {
+    $user = createTestUser();
+    $message = assistantMessageFor($user);
+
+    swapFilamentForFeedbackTest($user);
+
+    $chat = new CopilotChat;
+    $chat->loadConversation($message->conversation_id);
+    $chat->submitRating($message->id, 'positive');
+
+    $rated = collect($chat->messages)->firstWhere('id', $message->id);
+
+    expect($rated['rating'])->toBe('positive');
+});
+
+it('rejects an unknown rating value', function () {
+    $user = createTestUser();
+    $message = assistantMessageFor($user);
+
+    swapFilamentForFeedbackTest($user);
+
+    $chat = new CopilotChat;
+    $chat->submitRating($message->id, 'brilliant');
+
+    expect($message->fresh()->rating)->toBeNull();
+});
+
+it('refuses to rate a message that is not from the assistant', function () {
+    $user = createTestUser();
+    $assistantMessage = assistantMessageFor($user);
+
+    $userMessage = CopilotMessage::query()
+        ->where('conversation_id', $assistantMessage->conversation_id)
+        ->where('role', MessageRole::User->value)
+        ->firstOrFail();
+
+    swapFilamentForFeedbackTest($user);
+
+    $chat = new CopilotChat;
+    $chat->submitRating($userMessage->id, 'positive');
+
+    expect($userMessage->fresh()->rating)->toBeNull();
+});
+
+it('refuses to rate a message in another users conversation', function () {
+    $actor = createTestUser();
+    $victim = createTestUser();
+
+    $message = assistantMessageFor($victim);
+
+    swapFilamentForFeedbackTest($actor);
+
+    $chat = new CopilotChat;
+    $chat->submitRating($message->id, 'negative');
+
+    expect($message->fresh()->rating)->toBeNull();
+});
+
+it('refuses to rate a message from another panel', function () {
+    $user = createTestUser();
+
+    $message = assistantMessageFor($user, 'app');
+
+    swapFilamentForFeedbackTest($user, 'admin');
+
+    $chat = new CopilotChat;
+    $chat->submitRating($message->id, 'negative');
+
+    expect($message->fresh()->rating)->toBeNull();
+});
+
+it('refuses to rate when there is no authenticated user', function () {
+    $user = createTestUser();
+    $message = assistantMessageFor($user);
+
+    swapFilamentForFeedbackTest(null);
+
+    $chat = new CopilotChat;
+    $chat->submitRating($message->id, 'negative');
+
+    expect($message->fresh()->rating)->toBeNull();
+});
+
+it('refuses to rate while message feedback is disabled', function () {
+    $user = createTestUser();
+    $message = assistantMessageFor($user);
+
+    config()->set('filament-copilot.feedback.enabled', false);
+
+    swapFilamentForFeedbackTest($user);
+
+    $chat = new CopilotChat;
+    $chat->submitRating($message->id, 'positive');
+
+    expect($message->fresh()->rating)->toBeNull();
+});
+
+it('attaches the streamed message id to the pushed assistant message', function () {
+    $user = createTestUser();
+    $message = assistantMessageFor($user);
+
+    swapFilamentForFeedbackTest($user);
+
+    $chat = new CopilotChat;
+    $chat->handleStreamComplete(
+        content: 'Revenue is $1,200 this month.',
+        newConversationId: $message->conversation_id,
+        toolCalls: null,
+        messageId: $message->id,
+    );
+
+    $pushed = end($chat->messages);
+
+    expect($pushed['role'])->toBe('assistant')
+        ->and($pushed['id'])->toBe($message->id)
+        ->and($pushed['rating'])->toBeNull();
+
+    // ...and the reply is immediately ratable.
+    $chat->submitRating($pushed['id'], 'positive');
+
+    expect($message->fresh()->rating)->toBe(MessageRating::Positive);
+});
+
+it('pushes the assistant message without an id when the stream sends none', function () {
+    $user = createTestUser();
+    $conversation = CopilotConversation::create([
+        'participant_type' => $user->getMorphClass(),
+        'participant_id' => $user->getKey(),
+        'panel_id' => 'admin',
+        'title' => 'Legacy Published View',
+    ]);
+
+    swapFilamentForFeedbackTest($user);
+
+    $chat = new CopilotChat;
+    $chat->handleStreamComplete('Hello there', $conversation->id);
+
+    $pushed = end($chat->messages);
+
+    expect($pushed)->toBe([
+        'role' => 'assistant',
+        'content' => 'Hello there',
+    ]);
+});

--- a/tests/Unit/Services/ConversationManagerTest.php
+++ b/tests/Unit/Services/ConversationManagerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use EslamRedaDiv\FilamentCopilot\Enums\MessageRating;
 use EslamRedaDiv\FilamentCopilot\Enums\MessageRole;
 use EslamRedaDiv\FilamentCopilot\Enums\ToolCallStatus;
 use EslamRedaDiv\FilamentCopilot\Models\CopilotConversation;
@@ -114,4 +115,22 @@ it('gets messages formatted for chat with tool calls in order', function () {
         ->and($messages[1]['arguments'])->toMatchArray(['days' => 7])
         ->and($messages[1]['result'])->toBe('Report generated')
         ->and($messages[2]['role'])->toBe('assistant');
+});
+
+it('gets messages formatted for chat with the message id and rating', function () {
+    $user = createTestUser();
+    $manager = app(ConversationManager::class);
+    $conversation = $manager->create($user, 'admin');
+
+    $userMessage = $manager->addUserMessage($conversation, 'Generate a report for the last 7 days');
+    $assistantMessage = $manager->addAssistantMessage($conversation, 'Done. I generated the report.');
+    $assistantMessage->update(['rating' => MessageRating::Negative]);
+
+    $messages = $manager->getMessagesForChat($conversation);
+
+    expect($messages)->toHaveCount(2)
+        ->and($messages[0]['id'])->toBe($userMessage->id)
+        ->and($messages[0]['rating'])->toBeNull()
+        ->and($messages[1]['id'])->toBe($assistantMessage->id)
+        ->and($messages[1]['rating'])->toBe('negative');
 });

--- a/tests/Unit/Streaming/StreamMessageIdTest.php
+++ b/tests/Unit/Streaming/StreamMessageIdTest.php
@@ -1,0 +1,143 @@
+<?php
+
+use EslamRedaDiv\FilamentCopilot\Agent\CopilotAgent;
+use EslamRedaDiv\FilamentCopilot\Enums\MessageRole;
+use EslamRedaDiv\FilamentCopilot\FilamentCopilotPlugin;
+use EslamRedaDiv\FilamentCopilot\Http\Controllers\StreamController;
+use EslamRedaDiv\FilamentCopilot\Models\CopilotMessage;
+use EslamRedaDiv\FilamentCopilot\Services\ToolRegistry;
+use Filament\Facades\Filament;
+use Illuminate\Http\Request;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\StreamableAgentResponse;
+use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\TextDelta;
+
+function swapFilamentForStreamMessageIdTest($user, string $panelId = 'admin'): void
+{
+    $plugin = new FilamentCopilotPlugin;
+
+    $panel = new class($panelId)
+    {
+        public function __construct(private string $id) {}
+
+        public function getId(): string
+        {
+            return $this->id;
+        }
+    };
+
+    $guard = new class($user)
+    {
+        public function __construct(private $user) {}
+
+        public function user()
+        {
+            return $this->user;
+        }
+    };
+
+    $manager = new class($guard, $panel, $plugin)
+    {
+        public function __construct(private $guard, private $panel, private FilamentCopilotPlugin $plugin) {}
+
+        public function getPlugin(string $pluginId): FilamentCopilotPlugin
+        {
+            return $this->plugin;
+        }
+
+        public function auth()
+        {
+            return $this->guard;
+        }
+
+        public function setCurrentPanel(string $panelId): void {}
+
+        public function getCurrentPanel()
+        {
+            return $this->panel;
+        }
+
+        public function getTenant()
+        {
+            return null;
+        }
+    };
+
+    app()->instance('filament', $manager);
+    Filament::swap($manager);
+}
+
+function fakeTextOnlyAgent(string $reply): void
+{
+    $toolRegistry = Mockery::mock(ToolRegistry::class);
+    $toolRegistry->shouldReceive('buildTools')->andReturn([]);
+    app()->instance(ToolRegistry::class, $toolRegistry);
+
+    $timestamp = time();
+
+    $streamResponse = new StreamableAgentResponse(
+        invocationId: 'invocation-1',
+        generator: function () use ($reply, $timestamp) {
+            yield new TextDelta('event-1', 'assistant-message-1', $reply, $timestamp);
+            yield new StreamEnd('event-2', 'stop', new Usage(promptTokens: 5, completionTokens: 7), $timestamp + 1);
+        },
+        meta: new Meta(provider: 'openai', model: 'gpt-4o'),
+    );
+
+    $agent = Mockery::mock(CopilotAgent::class);
+    $agent->shouldReceive('forPanel')->andReturnSelf();
+    $agent->shouldReceive('forUser')->andReturnSelf();
+    $agent->shouldReceive('forTenant')->andReturnSelf();
+    $agent->shouldReceive('withTools')->andReturnSelf();
+    $agent->shouldReceive('withMessages')->andReturnSelf();
+    $agent->shouldReceive('withSystemPrompt')->andReturnSelf();
+    $agent->shouldReceive('stream')->andReturn($streamResponse);
+    app()->instance(CopilotAgent::class, $agent);
+}
+
+/**
+ * Run a stream request and return the raw SSE body.
+ *
+ * Three buffer levels: the controller discards the innermost one before it
+ * starts writing, and `sendSseEvent()` calls `ob_flush()` after every event —
+ * so the events land in the middle level and are flushed into the outermost
+ * one, which is what gets returned.
+ */
+function captureStreamOutput(string $message = 'What is the total revenue?'): string
+{
+    $response = app(StreamController::class)->stream(Request::create('/copilot/stream', 'POST', [
+        'message' => $message,
+        'panel_id' => 'admin',
+    ]));
+
+    $initialBufferLevel = ob_get_level();
+
+    ob_start();
+    ob_start();
+    ob_start();
+
+    $response->sendContent();
+
+    while (ob_get_level() > $initialBufferLevel + 1) {
+        ob_end_flush();
+    }
+
+    return (string) ob_get_clean();
+}
+
+it('sends the persisted assistant message id in the done event', function () {
+    $user = createTestUser();
+    swapFilamentForStreamMessageIdTest($user);
+    fakeTextOnlyAgent('Revenue is $1,200 this month.');
+
+    $output = captureStreamOutput();
+
+    $assistantMessage = CopilotMessage::query()
+        ->where('role', MessageRole::Assistant->value)
+        ->firstOrFail();
+
+    expect($output)->toContain('event: done')
+        ->toContain('"message_id":"'.$assistantMessage->id.'"');
+});

--- a/tests/Unit/Views/ChatMessageFeedbackTest.php
+++ b/tests/Unit/Views/ChatMessageFeedbackTest.php
@@ -1,0 +1,67 @@
+<?php
+
+function renderChatMessage(array $msg): string
+{
+    return view('filament-copilot::components.chat-message', ['msg' => $msg])->render();
+}
+
+it('renders feedback buttons on a persisted assistant message', function () {
+    $html = renderChatMessage([
+        'role' => 'assistant',
+        'content' => 'Revenue is $1,200 this month.',
+        'id' => '01hqxk8k0000000000000000',
+        'rating' => null,
+    ]);
+
+    expect($html)->toContain("submitRating('01hqxk8k0000000000000000', 'positive')")
+        ->toContain("submitRating('01hqxk8k0000000000000000', 'negative')")
+        ->toContain('Helpful')
+        ->toContain('Not helpful')
+        ->toContain('aria-pressed="false"');
+});
+
+it('marks the submitted rating as pressed', function () {
+    $html = renderChatMessage([
+        'role' => 'assistant',
+        'content' => 'Revenue is $1,200 this month.',
+        'id' => '01hqxk8k0000000000000000',
+        'rating' => 'negative',
+    ]);
+
+    expect($html)->toContain('Remove unhelpful rating')
+        ->toContain('aria-pressed="true"')
+        ->not->toContain('Remove helpful rating');
+});
+
+it('renders no feedback buttons on a message without an id', function () {
+    $html = renderChatMessage([
+        'role' => 'assistant',
+        'content' => 'Revenue is $1,200 this month.',
+    ]);
+
+    expect($html)->not->toContain('submitRating');
+});
+
+it('renders no feedback buttons while message feedback is disabled', function () {
+    config()->set('filament-copilot.feedback.enabled', false);
+
+    $html = renderChatMessage([
+        'role' => 'assistant',
+        'content' => 'Revenue is $1,200 this month.',
+        'id' => '01hqxk8k0000000000000000',
+        'rating' => 'positive',
+    ]);
+
+    expect($html)->not->toContain('submitRating');
+});
+
+it('renders no feedback buttons on a user message', function () {
+    $html = renderChatMessage([
+        'role' => 'user',
+        'content' => 'What is the total revenue?',
+        'id' => '01hqxk8k0000000000000000',
+        'rating' => null,
+    ]);
+
+    expect($html)->not->toContain('submitRating');
+});


### PR DESCRIPTION
Phase 1 of the message feedback proposal in (#18)

Adds the functionality proposed in Phase 1.

Chat side: a nullable `rating` column on copilot_messages ('positive' /'negative' / null, backed by the new MessageRating enum), and two thumb buttons under every assistant bubble. One click rates, clicking the lit thumb again clears it.

CopilotChat::submitRating() is authorization-first: the message is re-resolved in the database through the same forPanel/forParticipant/forTenant scoping every other conversation lookup in the package uses, before the rating value is validated and before the role is checked. A message that belongs to somebody else must not even reveal that it exists, so every rejection is the same silent no-op.

ConversationManager::getMessagesForChat() now also returns the persisted message id and rating, which the chat blade needs to submit against and to render the active thumb.

Streaming: StreamController now includes the persisted assistant message id in the SSE `done` payload, and the chat view threads it through the `copilot-stream-complete` dispatch into handleStreamComplete(). The reply a user is most likely to rate is the one that just streamed, and this is what lets the component address it exactly instead of inferring it. Both ends are backward compatible: `$messageId` is an optional trailing parameter, and a
published copy of the chat view that predates the payload keeps working - its replies simply render without thumbs until the conversation is reloaded.

Management: the conversations table gains a Thumbs Down badge column (shown only for conversations that collected one) and a "Has Negative Rating" ternary filter, so admins can jump straight to the problem conversations and read the exchange in context.

All of it is behind `filament-copilot.feedback.enabled`, default true: disabling hides the buttons and refuses writes, while ratings already recorded stay in the column and keep being reported in the management UI. Every new string goes through the package's translation file.

Added new tests, all green